### PR TITLE
Environment variable cleanup

### DIFF
--- a/houdini/16.5.536/package.py
+++ b/houdini/16.5.536/package.py
@@ -25,15 +25,14 @@ def commands():
     from rez.utils import system
     from rez import config
 
-    with system.add_sys_paths([config.config.package_definition_python_path]):
-        from rezzurect import chooser
+    from rezzurect import chooser
 
-        chooser.add_common_commands(
-            'houdini',
-            version=str(version),
-            env=env,
-            alias=alias,
-        )
+    chooser.add_common_commands(
+        'houdini',
+        version=str(version),
+        env=env,
+        alias=alias,
+    )
 
 
 timestamp = 1537925779

--- a/houdini/16.5.536/package.py
+++ b/houdini/16.5.536/package.py
@@ -22,9 +22,6 @@ build_command = "python {root}/rezbuild.py {install}"
 def commands():
     '''Create the environment variables and aliases needed to run this product.'''
     # IMPORT THIRD-PARTY LIBRARIES
-    from rez.utils import system
-    from rez import config
-
     from rezzurect import chooser
 
     chooser.add_common_commands(

--- a/houdini/16.5.536/package.py
+++ b/houdini/16.5.536/package.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-'''The main package definition for Nuke 11.2v3.'''
+'''The main package definition for Houdini 16.5.536.'''
 
 name = 'houdini'
 

--- a/houdini/17.0.352/package.py
+++ b/houdini/17.0.352/package.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-'''The main package definition for Nuke 11.2v3.'''
+'''The main package definition for Houdini 17.0.352'''
 
 name = 'houdini'
 
@@ -22,18 +22,14 @@ build_command = "python {root}/rezbuild.py {install}"
 def commands():
     '''Create the environment variables and aliases needed to run this product.'''
     # IMPORT THIRD-PARTY LIBRARIES
-    from rez.utils import system
-    from rez import config
+    from rezzurect import chooser
 
-    with system.add_sys_paths([config.config.package_definition_python_path]):
-        from rezzurect import chooser
-
-        chooser.add_common_commands(
-            'houdini',
-            version=str(version),
-            env=env,
-            alias=alias,
-        )
+    chooser.add_common_commands(
+        'houdini',
+        version=str(version),
+        env=env,
+        alias=alias,
+    )
 
 
 timestamp = 1537925779

--- a/houdini/17.0.352/rezbuild.py
+++ b/houdini/17.0.352/rezbuild.py
@@ -1,24 +1,19 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-'''The main module which installs Nuke onto the user's system.'''
+'''The main module which installs Houdini onto the user's system.'''
 
 # IMPORT STANDARD LIBRARIES
 import sys
 import os
 
-# IMPORT THIRD-PARTY LIBRARIES
-from rez.utils import system
-from rez import config
-
 
 def build(source_path, build_path, install_path, targets):
-    with system.add_sys_paths([config.config.package_definition_python_path]):
-        # IMPORT THIRD-PARTY LIBRARIES
-        from rezzurect import manager
+    # IMPORT THIRD-PARTY LIBRARIES
+    from rezzurect import manager
 
-        rezzurect_destination = os.path.join(install_path, 'python')
-        manager.copy_rezzurect_to(rezzurect_destination)
+    rezzurect_destination = os.path.join(install_path, 'python')
+    manager.copy_rezzurect_to(rezzurect_destination)
 
 
 if __name__ == '__main__':

--- a/houdini_installation/16.5.536/package.py
+++ b/houdini_installation/16.5.536/package.py
@@ -12,6 +12,8 @@ authors = ['SideFX']
 
 install_root = 'install'
 
+requires = ['respawn_includes-1.0.0']
+
 build_command = "python {root}/rezbuild.py {install}"
 
 
@@ -21,21 +23,17 @@ def commands():
     import os
 
     # IMPORT THIRD-PARTY LIBRARIES
-    from rez.utils import system
-    from rez import config
+    from rezzurect import chooser
 
-    with system.add_sys_paths([config.config.package_definition_python_path]):
-        from rezzurect import chooser
+    install_root = 'install'
+    env.INSTALL_ROOT = os.path.join('{root}', install_root)
 
-        install_root = 'install'
-        env.INSTALL_ROOT = os.path.join('{root}', install_root)
-
-        chooser.add_common_commands(
-            'houdini_installation',
-            version=str(version),
-            env=env,
-            alias=alias,
-        )
+    chooser.add_common_commands(
+        'houdini_installation',
+        version=str(version),
+        env=env,
+        alias=alias,
+    )
 
 
 timestamp = 1537925779

--- a/houdini_installation/16.5.536/rezbuild.py
+++ b/houdini_installation/16.5.536/rezbuild.py
@@ -7,30 +7,25 @@
 import sys
 import os
 
-# IMPORT THIRD-PARTY LIBRARIES
-from rez.utils import system
-from rez import config
-
 
 def build(source_path, build_path, install_path, targets):
-    with system.add_sys_paths([config.config.package_definition_python_path]):
-        # IMPORT THIRD-PARTY LIBRARIES
-        from rezzurect import environment
-        from rezzurect import chooser
-        from rezzurect import manager
+    # IMPORT THIRD-PARTY LIBRARIES
+    from rezzurect import environment
+    from rezzurect import chooser
+    from rezzurect import manager
 
-        # TODO : Get this information some better way
-        package_install_path = os.path.join(install_path, 'install')
-        version = os.environ['REZ_BUILD_PROJECT_VERSION']
-        package_name = 'houdini_installation'
+    # TODO : Get this information some better way
+    package_install_path = os.path.join(install_path, 'install')
+    version = os.environ['REZ_BUILD_PROJECT_VERSION']
+    package_name = 'houdini_installation'
 
-        environment.init(source_path, package_install_path)
+    environment.init(source_path, package_install_path)
 
-        adapter = chooser.get_build_adapter(package_name, version)
-        adapter.make_install()
+    adapter = chooser.get_build_adapter(package_name, version)
+    adapter.make_install()
 
-        rezzurect_destination = os.path.join(install_path, 'python')
-        manager.copy_rezzurect_to(rezzurect_destination)
+    rezzurect_destination = os.path.join(install_path, 'python')
+    manager.copy_rezzurect_to(rezzurect_destination)
 
 
 if __name__ == '__main__':

--- a/houdini_installation/17.0.352/package.py
+++ b/houdini_installation/17.0.352/package.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 
-'''The main package definition for Houdini 17.0.0352.'''
+'''The main package definition for Houdini 17.0.352.'''
 
 name = 'houdini_installation'
 
-version = '17.0.0352'
+version = '17.0.352'
 
-description = 'Houdini 17.0.0352'
+description = 'Houdini 17.0.352'
 
 authors = ['SideFX']
 

--- a/houdini_installation/17.0.352/package.py
+++ b/houdini_installation/17.0.352/package.py
@@ -1,16 +1,18 @@
 # -*- coding: utf-8 -*-
 
-'''The main package definition for Houdini 17.0.352.'''
+'''The main package definition for Houdini 17.0.0352.'''
 
 name = 'houdini_installation'
 
-version = '17.0.352'
+version = '17.0.0352'
 
-description = 'Houdini 17.0.352'
+description = 'Houdini 17.0.0352'
 
 authors = ['SideFX']
 
 install_root = 'install'
+
+requires = ['respawn_includes-1.0.0']
 
 build_command = "python {root}/rezbuild.py {install}"
 
@@ -21,21 +23,17 @@ def commands():
     import os
 
     # IMPORT THIRD-PARTY LIBRARIES
-    from rez.utils import system
-    from rez import config
+    from rezzurect import chooser
 
-    with system.add_sys_paths([config.config.package_definition_python_path]):
-        from rezzurect import chooser
+    install_root = 'install'
+    env.INSTALL_ROOT = os.path.join('{root}', install_root)
 
-        install_root = 'install'
-        env.INSTALL_ROOT = os.path.join('{root}', install_root)
-
-        chooser.add_common_commands(
-            'houdini_installation',
-            version=str(version),
-            env=env,
-            alias=alias,
-        )
+    chooser.add_common_commands(
+        'houdini_installation',
+        version=str(version),
+        env=env,
+        alias=alias,
+    )
 
 
 timestamp = 1537925779

--- a/houdini_installation/17.0.352/rezbuild.py
+++ b/houdini_installation/17.0.352/rezbuild.py
@@ -7,30 +7,25 @@
 import sys
 import os
 
-# IMPORT THIRD-PARTY LIBRARIES
-from rez.utils import system
-from rez import config
-
 
 def build(source_path, build_path, install_path, targets):
-    with system.add_sys_paths([config.config.package_definition_python_path]):
-        # IMPORT THIRD-PARTY LIBRARIES
-        from rezzurect import environment
-        from rezzurect import chooser
-        from rezzurect import manager
+    # IMPORT THIRD-PARTY LIBRARIES
+    from rezzurect import environment
+    from rezzurect import chooser
+    from rezzurect import manager
 
-        # TODO : Get this information some better way
-        package_install_path = os.path.join(install_path, 'install')
-        version = os.environ['REZ_BUILD_PROJECT_VERSION']
-        package_name = 'houdini_installation'
+    # TODO : Get this information some better way
+    package_install_path = os.path.join(install_path, 'install')
+    version = os.environ['REZ_BUILD_PROJECT_VERSION']
+    package_name = 'houdini_installation'
 
-        environment.init(source_path, package_install_path)
+    environment.init(source_path, package_install_path)
 
-        adapter = chooser.get_build_adapter(package_name, version)
-        adapter.make_install()
+    adapter = chooser.get_build_adapter(package_name, version)
+    adapter.make_install()
 
-        rezzurect_destination = os.path.join(install_path, 'python')
-        manager.copy_rezzurect_to(rezzurect_destination)
+    rezzurect_destination = os.path.join(install_path, 'python')
+    manager.copy_rezzurect_to(rezzurect_destination)
 
 
 if __name__ == '__main__':

--- a/nuke/10.5v8/rezbuild.py
+++ b/nuke/10.5v8/rezbuild.py
@@ -7,18 +7,13 @@
 import sys
 import os
 
-# IMPORT THIRD-PARTY LIBRARIES
-from rez.utils import system
-from rez import config
-
 
 def build(source_path, build_path, install_path, targets):
-    with system.add_sys_paths([config.config.package_definition_python_path]):
-        # IMPORT THIRD-PARTY LIBRARIES
-        from rezzurect import manager
+    # IMPORT THIRD-PARTY LIBRARIES
+    from rezzurect import manager
 
-        rezzurect_destination = os.path.join(install_path, 'python')
-        manager.copy_rezzurect_to(rezzurect_destination)
+    rezzurect_destination = os.path.join(install_path, 'python')
+    manager.copy_rezzurect_to(rezzurect_destination)
 
 
 if __name__ == '__main__':

--- a/nuke_installation/10.5v8/package.py
+++ b/nuke_installation/10.5v8/package.py
@@ -12,6 +12,8 @@ authors = ['Foundry']
 
 install_root = 'install'
 
+requires = ['respawn_includes-1.0.0']
+
 build_command = "python {root}/rezbuild.py {install}"
 
 
@@ -21,25 +23,21 @@ def commands():
     import os
 
     # IMPORT THIRD-PARTY LIBRARIES
-    from rez.utils import system
-    from rez import config
+    from rezzurect import chooser
 
-    with system.add_sys_paths([config.config.package_definition_python_path]):
-        from rezzurect import chooser
+    install_root = 'install'
+    install_folder = os.path.join('{root}', install_root)
+    env.INSTALL_ROOT = install_folder
 
-        install_root = 'install'
-        install_folder = os.path.join('{root}', install_root)
-        env.INSTALL_ROOT = install_folder
+    if os.path.isdir(env.INSTALL_ROOT.get()):
+        env.PATH.append(env.INSTALL_ROOT.get())
 
-        if os.path.isdir(env.INSTALL_ROOT.get()):
-            env.PATH.append(env.INSTALL_ROOT.get())
-
-        chooser.add_common_commands(
-            'nuke_installation',
-            version=str(version),
-            env=env,
-            alias=alias,
-        )
+    chooser.add_common_commands(
+        'nuke_installation',
+        version=str(version),
+        env=env,
+        alias=alias,
+    )
 
 
 timestamp = 1537925779

--- a/nuke_installation/10.5v8/rezbuild.py
+++ b/nuke_installation/10.5v8/rezbuild.py
@@ -7,30 +7,24 @@
 import sys
 import os
 
-# IMPORT THIRD-PARTY LIBRARIES
-from rez.utils import system
-from rez import config
-
-
 def build(source_path, build_path, install_path, targets):
-    with system.add_sys_paths([config.config.package_definition_python_path]):
-        # IMPORT THIRD-PARTY LIBRARIES
-        from rezzurect import environment
-        from rezzurect import chooser
-        from rezzurect import manager
+    # IMPORT THIRD-PARTY LIBRARIES
+    from rezzurect import environment
+    from rezzurect import chooser
+    from rezzurect import manager
 
-        # TODO : Get this information some better way
-        package_install_path = os.path.join(install_path, 'install')
-        version = os.environ['REZ_BUILD_PROJECT_VERSION']
-        package_name = 'nuke_installation'
+    # TODO : Get this information some better way
+    package_install_path = os.path.join(install_path, 'install')
+    version = os.environ['REZ_BUILD_PROJECT_VERSION']
+    package_name = 'nuke_installation'
 
-        environment.init(source_path, package_install_path)
+    environment.init(source_path, package_install_path)
 
-        adapter = chooser.get_build_adapter(package_name, version)
-        adapter.make_install()
+    adapter = chooser.get_build_adapter(package_name, version)
+    adapter.make_install()
 
-        rezzurect_destination = os.path.join(install_path, 'python')
-        manager.copy_rezzurect_to(rezzurect_destination)
+    rezzurect_destination = os.path.join(install_path, 'python')
+    manager.copy_rezzurect_to(rezzurect_destination)
 
 
 if __name__ == '__main__':

--- a/nuke_installation/11.2v3/package.py
+++ b/nuke_installation/11.2v3/package.py
@@ -12,6 +12,8 @@ authors = ['Foundry']
 
 install_root = 'install'
 
+requires = ['respawn_includes-1.0.0']
+
 build_command = "python {root}/rezbuild.py {install}"
 
 
@@ -21,25 +23,21 @@ def commands():
     import os
 
     # IMPORT THIRD-PARTY LIBRARIES
-    from rez.utils import system
-    from rez import config
+    from rezzurect import chooser
 
-    with system.add_sys_paths([config.config.package_definition_python_path]):
-        from rezzurect import chooser
+    install_root = 'install'
+    install_folder = os.path.join('{root}', install_root)
+    env.INSTALL_ROOT = install_folder
 
-        install_root = 'install'
-        install_folder = os.path.join('{root}', install_root)
-        env.INSTALL_ROOT = install_folder
+    if os.path.isdir(env.INSTALL_ROOT.get()):
+        env.PATH.append(env.INSTALL_ROOT.get())
 
-        if os.path.isdir(env.INSTALL_ROOT.get()):
-            env.PATH.append(env.INSTALL_ROOT.get())
-
-        chooser.add_common_commands(
-            'nuke_installation',
-            version=str(version),
-            env=env,
-            alias=alias,
-        )
+    chooser.add_common_commands(
+        'nuke_installation',
+        version=str(version),
+        env=env,
+        alias=alias,
+    )
 
 
 timestamp = 1537925779

--- a/nuke_installation/11.2v3/rezbuild.py
+++ b/nuke_installation/11.2v3/rezbuild.py
@@ -7,30 +7,24 @@
 import sys
 import os
 
-# IMPORT THIRD-PARTY LIBRARIES
-from rez.utils import system
-from rez import config
-
-
 def build(source_path, build_path, install_path, targets):
-    with system.add_sys_paths([config.config.package_definition_python_path]):
-        # IMPORT THIRD-PARTY LIBRARIES
-        from rezzurect import environment
-        from rezzurect import chooser
-        from rezzurect import manager
+    # IMPORT THIRD-PARTY LIBRARIES
+    from rezzurect import environment
+    from rezzurect import chooser
+    from rezzurect import manager
 
-        # TODO : Get this information some better way
-        package_install_path = os.path.join(install_path, 'install')
-        version = os.environ['REZ_BUILD_PROJECT_VERSION']
-        package_name = 'nuke_installation'
+    # TODO : Get this information some better way
+    package_install_path = os.path.join(install_path, 'install')
+    version = os.environ['REZ_BUILD_PROJECT_VERSION']
+    package_name = 'nuke_installation'
 
-        environment.init(source_path, package_install_path)
+    environment.init(source_path, package_install_path)
 
-        adapter = chooser.get_build_adapter(package_name, version)
-        adapter.make_install()
+    adapter = chooser.get_build_adapter(package_name, version)
+    adapter.make_install()
 
-        rezzurect_destination = os.path.join(install_path, 'python')
-        manager.copy_rezzurect_to(rezzurect_destination)
+    rezzurect_destination = os.path.join(install_path, 'python')
+    manager.copy_rezzurect_to(rezzurect_destination)
 
 
 if __name__ == '__main__':

--- a/respawn_includes/1.0.0/build/.gitignore
+++ b/respawn_includes/1.0.0/build/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/respawn_includes/1.0.0/package.py
+++ b/respawn_includes/1.0.0/package.py
@@ -18,7 +18,14 @@ def commands():
     import os
 
     additional_python_paths = os.getenv('RESPAWN_PYTHONPATH', '').split(os.pathsep)
-    sys.path.extend(additional_python_paths)  # TODO : Check if I need this line. Delete if not
 
+    # Any Rez package that adds this package into `requires` will need to
+    # have these paths added to `sys.path`. Otherwise, package.py will fail
+    #
+    sys.path.extend(additional_python_paths)
+
+    # And we need to add the same paths to `env.PYTHONPATH` or `rezbuild.py`
+    # commands will fail to import `rezzurect`
+    #
     for path in additional_python_paths:
         env.PYTHONPATH.append(path)

--- a/respawn_includes/1.0.0/package.py
+++ b/respawn_includes/1.0.0/package.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+#
+
+name = 'respawn_includes'
+
+version = '1.0.0'
+
+description = ''
+
+authors = ['ColinKennedy']
+
+build_command = "python {root}/rezbuild.py {install}"
+
+
+def commands():
+    # IMPORT STANDARD LIBRARIES
+    import sys
+    import os
+
+    additional_python_paths = os.getenv('RESPAWN_PYTHONPATH', '').split(os.pathsep)
+    sys.path.extend(additional_python_paths)  # TODO : Check if I need this line. Delete if not
+
+    for path in additional_python_paths:
+        env.PYTHONPATH.append(path)

--- a/respawn_includes/1.0.0/rezbuild.py
+++ b/respawn_includes/1.0.0/rezbuild.py
@@ -1,19 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-'''The main module which installs Houdini onto the user's system.'''
-
 # IMPORT STANDARD LIBRARIES
 import sys
 import os
 
 
 def build(source_path, build_path, install_path, targets):
-    # IMPORT THIRD-PARTY LIBRARIES
-    from rezzurect import manager
-
-    rezzurect_destination = os.path.join(install_path, 'python')
-    manager.copy_rezzurect_to(rezzurect_destination)
+    pass
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Packages have been changed so that, instead of using environment variable context blocks, all packages inherit from a package called "respawn_includes" which takes care of making sure packages have what they need to execute.